### PR TITLE
Release/v1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "scss-allman-formatter",
 	"displayName": "SCSS Allman Formatter",
 	"description": "Formats braces to new lines (Allman style). SCSS & CSS formatter for VS Code",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"publisher": "GrantBartlett",
 	"icon": "images/icon.png",
 	"repository": {

--- a/src/SCSSFormatterProvider.ts
+++ b/src/SCSSFormatterProvider.ts
@@ -2,19 +2,34 @@ import { DocumentFormattingEditProvider, TextDocument, FormattingOptions, Cancel
 
 export class SCSSFormatterProvider implements DocumentFormattingEditProvider
 {
+    private linesToIgnore: Array<number> = [];
+    private changes = [];
+
     public provideDocumentFormattingEdits(document: TextDocument, options: FormattingOptions, token: CancellationToken): ProviderResult<TextEdit[]>
     {
-        const changes: ProviderResult<TextEdit[]> = [];
+        this.changes = [];
 
+        this.linesToIgnore = this.findCommentsReturnIgnoredLines(document);
+        this.format(document, options);
+
+        return this.changes;
+    }
+
+    private format(document: TextDocument, options: FormattingOptions): void
+    {
         for (let i = 0; i < document.lineCount; i++)
         {
             const line: TextLine = document.lineAt(i);
+
+            if (this.linesToIgnore.indexOf(line.lineNumber) > -1)
+            {
+                continue;
+            }
+
             const newLine = this.createNewLine(options.insertSpaces, line);
             const newText = line.text.replace(/(\S)(.+){\s*$/gm, newLine);
-            changes.push(TextEdit.replace(line.range, newText));
+            this.changes.push(TextEdit.replace(line.range, newText));
         }
-
-        return changes;
     }
 
     private createNewLine(insertSpaces: boolean, line: TextLine): string 
@@ -31,6 +46,41 @@ export class SCSSFormatterProvider implements DocumentFormattingEditProvider
         }
 
         return newLine;
+    }
+
+    private findCommentsReturnIgnoredLines(document: TextDocument): Array<number>
+    {
+        const ignoredLines = [];
+
+        let multiLineCommentFound = false;
+
+        for (let i = 0; i < document.lineCount; i++)
+        {
+            const line: TextLine = document.lineAt(i);
+            const scssCommentMatch = line.text.match(/(\/\/*)/);
+            if (scssCommentMatch !== null)
+            {
+                ignoredLines.push(line.lineNumber);
+            }
+
+            const cssMultiLineCommentMatch = line.text.match(/\/\*[^]/s);
+            if (cssMultiLineCommentMatch !== null && multiLineCommentFound === false)
+            {
+                multiLineCommentFound = true;
+            }
+
+            if (multiLineCommentFound === true)
+            {
+                ignoredLines.push(line.lineNumber);
+                const closing = line.text.match(/[^]\/\s*$/gm);
+                if (closing !== null)
+                {
+                    multiLineCommentFound = false;
+                }
+            }
+        }
+
+        return ignoredLines;
     }
 
     private repeat(value: string, count: number): string


### PR DESCRIPTION
- Ignores SCSS single line comments and CSS comments when formatting. Fixes a bug where it would format commented out SCSS. 